### PR TITLE
Implement the second stage of the parser in Flink to reduce overhead.

### DIFF
--- a/src/main/java/org/gradoop/examples/io/dblp/stream/DblpElementToEdge.java
+++ b/src/main/java/org/gradoop/examples/io/dblp/stream/DblpElementToEdge.java
@@ -1,0 +1,20 @@
+package org.gradoop.examples.io.dblp.stream;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.util.Collector;
+import org.gradoop.flink.io.impl.graph.tuples.ImportEdge;
+
+/**
+ * Extract {@link ImportEdge}s from {@link DblpImportElement}s.
+ */
+public class DblpElementToEdge implements FlatMapFunction<DblpImportElement, ImportEdge<String>> {
+
+    private final String LABEL_AUTHOR = "author";
+
+    @Override
+    public void flatMap(DblpImportElement value, Collector<ImportEdge<String>> out) {
+        for (String author : value.getAuthors()) {
+            out.collect(new ImportEdge<>(LABEL_AUTHOR + '|' + value.getKey(), author, value.getKey()));
+        }
+    }
+}

--- a/src/main/java/org/gradoop/examples/io/dblp/stream/DblpElementToVertex.java
+++ b/src/main/java/org/gradoop/examples/io/dblp/stream/DblpElementToVertex.java
@@ -1,0 +1,27 @@
+package org.gradoop.examples.io.dblp.stream;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.util.Collector;
+import org.gradoop.common.model.impl.properties.Properties;
+import org.gradoop.flink.io.impl.graph.tuples.ImportVertex;
+
+/**
+ * Extract {@link ImportVertex ImportVertices} from {@link DblpImportElement}s.
+ */
+public class DblpElementToVertex implements FlatMapFunction<DblpImportElement, ImportVertex<String>> {
+
+    private static final String LABEL_AUTHOR_NAME = "name";
+    private static final String PROP_TITLE = "title";
+
+    @Override
+    public void flatMap(DblpImportElement value, Collector<ImportVertex<String>> out) {
+        // Publication vertex.
+        out.collect(new ImportVertex<>(value.getKey(), value.getType(), value.getProperties()));
+        for (String author : value.getAuthors()) {
+            Properties authorProp = Properties.create();
+            authorProp.set(LABEL_AUTHOR_NAME, author);
+            out.collect(new ImportVertex<>(author, LABEL_AUTHOR_NAME, authorProp));
+        }
+
+    }
+}

--- a/src/main/java/org/gradoop/examples/io/dblp/stream/DblpImportElement.java
+++ b/src/main/java/org/gradoop/examples/io/dblp/stream/DblpImportElement.java
@@ -1,0 +1,71 @@
+package org.gradoop.examples.io.dblp.stream;
+
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.dblp.datastructures.DblpElement;
+import org.gradoop.common.model.impl.properties.Properties;
+
+/**
+ * A replacement for {@link org.dblp.datastructures.DblpElement} as a {@link org.apache.flink.api.java.tuple.Tuple}.
+ * T0: key,
+ * T1: typeName,
+ * T2: title,
+ * T3: authors,
+ * T4: properties
+ */
+public class DblpImportElement extends Tuple5<String, String, String, String[], Properties> {
+
+    private static final String PROP_TITLE = "title";
+
+    /**
+     * Constructor for serialization.
+     */
+    public DblpImportElement() {
+
+    }
+
+    public DblpImportElement(String key, String typeName, String title, String[] authors, Properties properties) {
+        super();
+        f0 = key;
+        f1 = typeName;
+        f2 = title;
+        f3 = authors;
+        f4 = properties;
+    }
+
+    /**
+     * Convert a {@link DblpElement} to a {@link DblpImportElement}.
+     *
+     * @param element The source element.
+     * @return The target element.
+     */
+    public static DblpImportElement fromElement(DblpElement element) {
+        Properties prop = new Properties();
+        for (String attrKey : element.attributes.keySet()) {
+            element.attributes.get(attrKey)
+                    .forEach(attribute -> prop.set(attrKey, attribute));
+        }
+        prop.set(PROP_TITLE, element.title);
+        return new DblpImportElement(element.key, element.getType().name(), element.title,
+                element.authors.toArray(new String[element.authors.size()]), prop);
+    }
+
+    public String[] getAuthors() {
+        return f3;
+    }
+
+    public String getKey() {
+        return f0;
+    }
+
+    public Properties getProperties() {
+        return f4;
+    }
+
+    public String getTitle() {
+        return f2;
+    }
+
+    public String getType() {
+        return f1;
+    }
+}

--- a/src/main/java/org/gradoop/examples/io/dblp/stream/FlinkSimpleGraph.java
+++ b/src/main/java/org/gradoop/examples/io/dblp/stream/FlinkSimpleGraph.java
@@ -1,0 +1,49 @@
+package org.gradoop.examples.io.dblp.stream;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.dblp.datastructures.DblpElement;
+import org.dblp.parser.DblpParser;
+import org.gradoop.examples.io.dblp.callback.SimpleDblpProcessor;
+import org.gradoop.flink.io.impl.graph.GraphDataSource;
+import org.gradoop.flink.io.impl.graph.tuples.ImportEdge;
+import org.gradoop.flink.io.impl.graph.tuples.ImportVertex;
+import org.gradoop.flink.io.impl.json.JSONDataSink;
+import org.gradoop.flink.model.api.epgm.LogicalGraph;
+import org.gradoop.flink.util.GradoopFlinkConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A replacement for {@link org.gradoop.examples.io.dblp.SimpleGraph} that uses Flink.
+ */
+public class FlinkSimpleGraph {
+
+    private static List<DblpElement> parseData(String uri, long numElements) {
+        SimpleDblpProcessor processor = new SimpleDblpProcessor(numElements);
+        DblpParser.load(processor, uri);
+        return processor.getElementList();
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 3) {
+            System.err.println("Usage: FlinkSimpleGraph INPUT_PATH ELEMENT_COUNT OUTPUT_PATH");
+            return;
+        }
+        ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+        GradoopFlinkConfig config = GradoopFlinkConfig.createConfig(env);
+        List<DblpImportElement> elementsIt = parseData(args[0], Long.parseLong(args[1])).stream()
+                .filter(ele -> ele.key != null)
+                .filter(ele -> ele.authors.size() != 0)
+                .filter(ele -> ele.title != null && !ele.title.equals(""))
+                .map(DblpImportElement::fromElement).collect(Collectors.toCollection(ArrayList::new));
+        DataSet<DblpImportElement> elements = env.fromCollection(elementsIt);
+        DataSet<ImportEdge<String>> edges = elements.flatMap(new DblpElementToEdge());
+        DataSet<ImportVertex<String>> vertices = elements.flatMap(new DblpElementToVertex());
+        LogicalGraph graph = new GraphDataSource<>(vertices, edges, config).getLogicalGraph();
+        new JSONDataSink(args[2], config).write(graph, true);
+        env.execute();
+    }
+}


### PR DESCRIPTION
Provides an alternative implementation to `SimpleGraph` in Flink.